### PR TITLE
Use auth-userdb instead of auth-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # haraka-plugin-dovecot
 
-Haraka mail plugin that checks whether a mailbox exists (Dovecot auth-master) and the SMTP-Auth per Dovecot (service auth is also used by Postfix) allowed.
+
+Haraka mail plugin that checks whether a mailbox exists (Dovecot auth-userdb) and the SMTP-Auth per Dovecot (service auth is also used by Postfix) allowed.
 
 ## USAGE
 

--- a/config/dovecot.ini
+++ b/config/dovecot.ini
@@ -4,12 +4,15 @@
 ; MAIL FROM address is deliverable.
 check_outbound=true
 
-; the path to dovecot/auth-master unix domain socket
+; the path to dovecot/auth-userdb unix domain socket
 ; When path is uncommented it is used by default and the host and port config
 ; form this main section will never used. Same is happend on domain section,
-; see [example.com]
-; default: path=/var/run/dovecot/auth-master
-path=/var/run/dovecot/auth-master
+; auth-userdb should be used in favor of auth-master due to security reasons
+; They both supports querying existence of user,
+; but auth-master supports more privileged operations
+; and shouldn't be exposed to all users.
+; default: path=/var/run/dovecot/auth-userdb
+path=/var/run/dovecot/auth-userdb
 
 ; the IP address of the host running dovecot for delivery
 ; default: host=127.0.0.1
@@ -20,7 +23,8 @@ path=/var/run/dovecot/auth-master
 ;port=8998
 
 
+; Domain-specific configurations
 ;[example.com]
-;path=/var/run/dovecot/auth-master
+;path=/var/run/dovecot/auth-userdb
 ;host=127.0.0.10
 ;port=8998

--- a/config/dovecot.ini
+++ b/config/dovecot.ini
@@ -5,16 +5,12 @@
 check_outbound=true
 
 ; the path to dovecot/auth-userdb unix domain socket
-; When path is uncommented it is used by default and the host and port config
-; form this main section will never used. Same is happend on domain section,
-; auth-userdb should be used in favor of auth-master due to security reasons
-; They both supports querying existence of user,
-; but auth-master supports more privileged operations
-; and shouldn't be exposed to all users.
+; When path is uncommented, it is used and the host and port config
+; in this config section will not be used. Same in the domain section.
 ; default: path=/var/run/dovecot/auth-userdb
 path=/var/run/dovecot/auth-userdb
 
-; the IP address of the host running dovecot for delivery
+; the IP address of the dovecot host
 ; default: host=127.0.0.1
 ;host=127.0.0.1
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ exports.get_dovecot_response = function (connection, domain, email, cb) {
     }
   }
 
-  socket_address = options.path ?
+  let socket_address = options.path ?
     options.path :
     `${options.host}:${options.port}`;
   connection.transaction.results.add(plugin, {

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ exports.get_dovecot_response = function (connection, domain, email, cb) {
     //'connect' listener
     connection.logprotocol(
       plugin,
-      `connect to Dovecot auth-master:${JSON.stringify(options)}`,
+      `connect to Dovecot auth-userdb:${JSON.stringify(options)}`,
     );
   });
 
@@ -153,10 +153,10 @@ exports.get_dovecot_response = function (connection, domain, email, cb) {
       client.end();
       cb(e);
     })
-    .on("end", () => {
-      connection.logprotocol(plugin, "closed connect to Dovecot auth-master");
-    });
-};
+    .on('end', () => {
+      connection.logprotocol(plugin, 'closed connect to Dovecot auth-userdb');
+    })
+}
 
 exports.check_dovecot_response = function (data) {
   if (data.match(/^VERSION\t\d+\t/i) && data.slice(-1) === "\n") {

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ exports.get_dovecot_response = function (connection, domain, email, cb) {
     }
   }
 
-  let socket_address = options.path ?
+  const socket_address = options.path ?
     options.path :
     `${options.host}:${options.port}`;
   connection.transaction.results.add(plugin, {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const net = require('node:net');
 
 exports.register = function () {
+  this.load_dovecot_ini();
   this.register_hook('rcpt', 'check_rcpt_on_dovecot');
   this.register_hook('mail', 'check_mail_on_dovecot');
 };

--- a/index.js
+++ b/index.js
@@ -122,6 +122,9 @@ exports.get_dovecot_response = function (connection, domain, email, cb) {
     }
   }
 
+  socket_address = options.path ?
+    options.path :
+    `${options.host}:${options.port}`;
   connection.transaction.results.add(plugin, {
     msg: `sock: ${options.host}:${options.port}`,
   });


### PR DESCRIPTION
For better security, Haraka shouldn't be run at root privileges.

Dovecot supports auth-userdb, which is safer to interact with, providing less privileges, but also suffices for validating users. 
auth-master by default has privilege 700, which users are discouraged from modifying:
[auth-master socket related configuration should be replaced with auth-userdb socket everywhere (auth-master should still work, but it gives more permissions than necessary)](https://doc.dovecot.org/2.3/installation_guide/upgrading/from-1.2-to-2.0/)